### PR TITLE
Fixed tab issues preventing make from running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,6 @@ debug:
 	cmake --build ./build --config Debug --target all -j 10
 
 all:
-    make clear
-    make protocols
+	make clear
+	make protocols
 	make release


### PR DESCRIPTION
Fixes issue with make where it outputs "Makefile:48: *** missing separator.  Stop." when attempting to run make command. I'm guessing that the makefile requires tabs over spaces